### PR TITLE
Add ability to end colors without resetting the prompt.

### DIFF
--- a/lib/ansi_colors.rb
+++ b/lib/ansi_colors.rb
@@ -2,36 +2,35 @@
 class String
   # The color commands understood by the overridden method_missing method.
   ANSI_CMDS = {
+    :bright               =>    [1, :normal],
+    :bold                 =>    [1, :normal],
+    :faint                =>    [2, :normal],
+    :italic               =>    [3, 23],
+    :underline            =>    [4, 24],
+    :blink_slow           =>    [5, 25],
+    :blink_rapid          =>    [6, 26],
+    :inverse              =>    [7, 27],
+    :conceal              =>    [8, 28],
+    :crossed_out          =>    [9, 29],
+    :black                =>    [30, :default_color],
+    :red                  =>    [31, :default_color],
+    :green                =>    [32, :default_color],
+    :yellow               =>    [33, :default_color],
+    :blue                 =>    [34, :default_color],
+    :magenta              =>    [35, :default_color],
+    :cyan                 =>    [36, :default_color],
+    :white                =>    [37, :default_color],
+    :bck_black            =>    [40, :default_background],
+    :bck_red              =>    [41, :default_background],
+    :bck_green            =>    [42, :default_background],
+    :bck_yellow           =>    [43, :default_background],
+    :bck_blue             =>    [44, :default_background],
+    :bck_magenta          =>    [45, :default_background],
+    :bck_cyan             =>    [46, :default_background],
+    :bck_white            =>    [47, :default_background],
     :reset                =>    0,
-    :bright               =>    1,
-    :bold                 =>    1,
-    :faint                =>    2,
-    :italic               =>    3,
-    :underline            =>    4,
-    :blink_slow           =>    5,
-    :blink_rapid          =>    6,
-    :inverse              =>    7,
-    :conceal              =>    8,
-    :crossed_out          =>    9,
-    :underline2           =>    21,
     :normal               =>    22,
-    :black                =>    30,
-    :red                  =>    31,
-    :green                =>    32,
-    :yellow               =>    33,
-    :blue                 =>    34,
-    :magenta              =>    35,
-    :cyan                 =>    36,
-    :white                =>    37,
     :default_color        =>    39,
-    :bck_black            =>    40,
-    :bck_red              =>    41,
-    :bck_green            =>    42,
-    :bck_yellow           =>    43,
-    :bck_blue             =>    44,
-    :bck_magenta          =>    45,
-    :bck_cyan             =>    46,
-    :bck_white            =>    47,
     :default_background   =>    49		
   }
   
@@ -49,8 +48,8 @@ class String
   # Adds escape chars to the string so that it appears coloured when printed on an
   # ansi compliant terminal (non-ansi terminals will display the string surrounded
   # by garbage-like stuff). col_code specifies the color to be used. 
-  def colorize(col_code)
-    "\033[#{col_code}m#{self}\033[0m"
+  def colorize(col_code, end_code)
+    "\033[#{col_code}m#{self}\033[#{end_code}m"
   end
   
   # Override method_missing in order to add methods to colorize the string. The
@@ -65,10 +64,18 @@ class String
     if symbol.to_s !~ /\Aansi_.*\Z/
       return super      
     end
-    
-    clr_id = ANSI_CMDS[symbol.to_s[5..-1].to_sym]
-    if clr_id
-      colorize(clr_id)
+
+    color_code = ANSI_CMDS[symbol.to_s[5..-1].to_sym]
+    end_code = :reset
+    if color_code.is_a?(Array)
+      color_code, end_code = color_code
+    end
+    if end_code.is_a?(Symbol)
+      end_code = ANSI_CMDS[end_code]
+    end
+
+    if color_code
+      colorize(color_code, end_code)
     else
       raise "Unknown ansi code"
     end


### PR DESCRIPTION
I'm attempting to make whitespace visible in a game I'm creating and invert needs to not reset the prompt. For example:

``` ruby
puts ("hello" + "∙∙∙".ansi_inverse + "world").ansi_red
```

![05_27_15 at 01 44 43pm](https://cloud.githubusercontent.com/assets/769039/7847142/93639dbe-0476-11e5-84ba-ce003fa9aa17.png)

Now we have:

![05_27_15 at 01 45 23pm](https://cloud.githubusercontent.com/assets/769039/7847155/ab8db6ea-0476-11e5-8fb0-d3649c7fea22.png)
